### PR TITLE
Rule Tweak

### DIFF
--- a/eslint-config/blui-rules.js
+++ b/eslint-config/blui-rules.js
@@ -48,6 +48,7 @@ const bluiRules = {
     '@typescript-eslint/no-unnecessary-qualifier': 'error',
     '@typescript-eslint/no-unnecessary-type-arguments': 'error',
     '@typescript-eslint/no-unsafe-assignment': 'off',
+    '@typescript-eslint/no-unsafe-argument': 'off',
     '@typescript-eslint/no-unsafe-call': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/no-unsafe-return': 'off',

--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/eslint-config",
-    "version": "3.0.0-beta.0",
+    "version": "3.0.0-beta.1",
     "description": "ESLint profile for Brightlayer UI",
     "author": "Brightlayer UI <brightlayer-ui@eaton.com>",
     "main": "index.js",


### PR DESCRIPTION

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- This rule `@typescript-eslint/no-unsafe-argument` was previously off, but after updating dependencies it has been switched on by default.  This PR switches this rule back to 'off' since it's causing some linting issues in our templates and can be perceived as more annoying than helpful.