### PR TITLE
Feature/3096 adjust rule

### DIFF
--- a/eslint-config/CHANGELOG.md
+++ b/eslint-config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v3.0.1 (Not yet published)
+
+### Changed
+
+- Eased `@typescript-eslint/naming-convention` rules to allow quoted properties ([#55](https://github.com/brightlayer-ui/code-standards/issues/55)).
+
 ## v3.0.0 (January 14, 2022)
 
 ### Changed

--- a/eslint-config/blui-rules.js
+++ b/eslint-config/blui-rules.js
@@ -17,6 +17,11 @@ const bluiRules = {
             format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
         },
         {
+            selector: 'property',
+            format: null,
+            modifiers: ['requiresQuotes']
+        },
+        {
             selector: 'enumMember',
             format: ['UPPER_CASE'],
         },

--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/eslint-config",
-    "version": "3.0.0",
+    "version": "3.0.1-beta.0",
     "description": "ESLint profile for Brightlayer UI",
     "author": "Brightlayer UI <brightlayer-ui@eaton.com>",
     "main": "index.js",


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #55 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Eased eslint naming convention rule for properties that require quotes.  E.g "100%", "@keyframes spin" would be fine.

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Use this repo: https://github.com/brightlayer-ui/react-cli-templates/tree/feature/enable-eslint-rule
- Update `node_modules/@brightlayer-ui/eslint-config/blui-rules.js` to include the new rule.
- `yarn lint` should run without issues. 

We will need to double-check this once the beta package is published, test all template repos. 
